### PR TITLE
Fixed text positioning

### DIFF
--- a/Creator.php
+++ b/Creator.php
@@ -359,7 +359,12 @@ class Creator {
         $y += $this->offset[1];
         $z += $this->offset[2];
         $angle = deg2rad($angle);
-        $this->shapes[] = "TEXT\n8\n{$this->layerName}\n10\n{$x}\n20\n{$y}\n30\n{$z}\n40\n{$textHeight}\n71\n{$position}\n1\n{$text}\n50\n{$angle}\n0\n";
+        
+        // Positioning of text
+        $horizontalJustification = ($position - 1) % 3;
+        $verticalJustification = 3 - intval(($position -1) / 3);
+        
+        $this->shapes[] = "TEXT\n8\n{$this->layerName}\n10\n{$x}\n20\n{$y}\n30\n{$z}\n40\n{$textHeight}\n72\n{$horizontalJustification}\n73\n{$verticalJustification}\n1\n{$text}\n50\n{$angle}\n0\n";
         return $this;
     }
 

--- a/Creator.php
+++ b/Creator.php
@@ -364,7 +364,7 @@ class Creator {
         $horizontalJustification = ($position - 1) % 3;
         $verticalJustification = 3 - intval(($position -1) / 3);
         
-        $this->shapes[] = "TEXT\n8\n{$this->layerName}\n10\n{$x}\n20\n{$y}\n30\n{$z}\n40\n{$textHeight}\n72\n{$horizontalJustification}\n73\n{$verticalJustification}\n1\n{$text}\n50\n{$angle}\n0\n";
+        $this->shapes[] = "TEXT\n8\n{$this->layerName}\n10\n{$x}\n20\n{$y}\n30\n{$z}\n11\n{$x}\n21\n{$y}\n31\n{$z}\n40\n{$textHeight}\n72\n{$horizontalJustification}\n73\n{$verticalJustification}\n1\n{$text}\n50\n{$angle}\n0\n";
         return $this;
     }
 


### PR DESCRIPTION
Thanks for the library!

Text positioning parameter was wrong, it used the wrong group code and values.
Fixed using correct group codes + adding secondary alignment points.

Code now works as intended:
Position of text from point: 1 = top-left; 2 = top-center; 3 = top-right; 4 = center-left; 5 = center; 6 = center-right; 7 = bottom-left; 8 = bottom-center; 9 = bottom-right
